### PR TITLE
Arrow function because of `this`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ store.subscribe(function(data) {
 ```js
 class MyComponent extends React.Component {
   componentDidMount() {
-    this.countSubscription = this.props.countStream.subscribe(function(count) {
+    this.countSubscription = this.props.countStream.subscribe((count) => {
       this.setState({count: count});
     });
   }


### PR DESCRIPTION
You probably want an arrow function here so you can use `this.setState()` where `this` == MyComponent instance.
